### PR TITLE
feat: add trash deposit logic

### DIFF
--- a/packages/trashy_road/lib/src/game/bloc/game_bloc.dart
+++ b/packages/trashy_road/lib/src/game/bloc/game_bloc.dart
@@ -9,8 +9,10 @@ part 'game_state.dart';
 class GameBloc extends Bloc<GameEvent, GameState> {
   GameBloc({required TiledMap map}) : super(GameState.initial(map: map)) {
     on<GameReadyEvent>(_onGameReady);
+    on<GameTrashAddedEvent>(_onGameTrashAdded);
     on<GameInteractedEvent>(_onGameInteraction);
     on<GameCollectedTrashEvent>(_onCollectedTrash);
+    on<GameDepositedTrashEvent>(_onDepositedTrash);
     on<GameResetEvent>(_onGameReset);
     on<GamePausedEvent>(_onGamePaused);
     on<GameResumedEvent>(_onGameResumed);
@@ -21,6 +23,13 @@ class GameBloc extends Bloc<GameEvent, GameState> {
     Emitter<GameState> emit,
   ) {
     emit(state.copyWith(status: GameStatus.ready));
+  }
+
+  void _onGameTrashAdded(
+    GameTrashAddedEvent event,
+    Emitter<GameState> emit,
+  ) {
+    emit(state.copyWith(trashRemaining: event.amountOfTrash));
   }
 
   void _onGameInteraction(
@@ -42,6 +51,28 @@ class GameBloc extends Bloc<GameEvent, GameState> {
       trash: state.inventory.trash + 1,
     );
     emit(state.copyWith(inventory: inventory));
+  }
+
+  void _onDepositedTrash(
+    GameDepositedTrashEvent event,
+    Emitter<GameState> emit,
+  ) {
+    if (state.inventory.trash > 0) {
+      final inventory = state.inventory.copyWith(
+        trash: state.inventory.trash - 1,
+      );
+      final trashRemaining = state.trashRemaining - 1;
+      if (trashRemaining == 0) {
+        emit(state.copyWith(status: GameStatus.completed));
+      } else {
+        emit(
+          state.copyWith(
+            inventory: inventory,
+            trashRemaining: trashRemaining,
+          ),
+        );
+      }
+    }
   }
 
   void _onGameReset(

--- a/packages/trashy_road/lib/src/game/bloc/game_event.dart
+++ b/packages/trashy_road/lib/src/game/bloc/game_event.dart
@@ -19,6 +19,22 @@ class GameReadyEvent extends GameEvent {
   List<Object?> get props => [];
 }
 
+/// {@template GameTrashAddedEvent}
+/// The trash has been added to the world
+///
+/// Fired when the map has been parsed and the total amount of trash in the
+/// world is known
+/// {@endtemplate}
+class GameTrashAddedEvent extends GameEvent {
+  /// {@macro GameTrashAddedEvent}
+  const GameTrashAddedEvent({required this.amountOfTrash}) : super();
+
+  final int amountOfTrash;
+
+  @override
+  List<Object?> get props => [amountOfTrash];
+}
+
 /// {@template GameInteractedEvent}
 /// The user has interacted with the game.
 ///
@@ -41,6 +57,19 @@ class GameInteractedEvent extends GameEvent {
 class GameCollectedTrashEvent extends GameEvent {
   /// {@macro GameCollectedTrashEvent}
   const GameCollectedTrashEvent() : super();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// {@template GameDepositedTrashEvent}
+/// The user has deposited trash.
+///
+/// Fired when the user has deposited a piece of trash into a Trash Can.
+/// {@endtemplate}
+class GameDepositedTrashEvent extends GameEvent {
+  /// {@macro GameDepositedTrashEvent}
+  const GameDepositedTrashEvent() : super();
 
   @override
   List<Object?> get props => [];

--- a/packages/trashy_road/lib/src/game/bloc/game_state.dart
+++ b/packages/trashy_road/lib/src/game/bloc/game_state.dart
@@ -21,6 +21,9 @@ enum GameStatus {
   /// Pausing the game means that all user input is disabled and moving objects
   /// are paused.
   paused,
+
+  /// The player has completed the level
+  completed
 }
 
 /// {@template GameState}
@@ -36,6 +39,7 @@ class GameState extends Equatable {
     required this.status,
     required this.map,
     required this.inventory,
+    required this.trashRemaining,
   });
 
   /// The initial state of the game.
@@ -44,6 +48,7 @@ class GameState extends Equatable {
           status: GameStatus.ready,
           map: map,
           inventory: const Inventory.empty(),
+          trashRemaining: -1,
         );
 
   /// {@macro GameStatus}
@@ -55,19 +60,23 @@ class GameState extends Equatable {
   /// {@macro Inventory}
   final Inventory inventory;
 
+  final int trashRemaining;
+
   GameState copyWith({
     GameStatus? status,
     Inventory? inventory,
+    int? trashRemaining,
   }) {
     return GameState(
       status: status ?? this.status,
       map: map,
       inventory: inventory ?? this.inventory,
+      trashRemaining: trashRemaining ?? this.trashRemaining,
     );
   }
 
   @override
-  List<Object?> get props => [status, inventory, map];
+  List<Object?> get props => [status, inventory, map, trashRemaining];
 }
 
 /// {@template Inventory}

--- a/packages/trashy_road/lib/src/game/components/trashy_road_world/trashy_road_world.dart
+++ b/packages/trashy_road/lib/src/game/components/trashy_road_world/trashy_road_world.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flame/components.dart';
+import 'package:flame_bloc/flame_bloc.dart';
 import 'package:flame_tiled/flame_tiled.dart';
 import 'package:trashy_road/src/game/entities/barrel/barrel.dart';
 import 'package:trashy_road/src/game/game.dart';
@@ -19,7 +20,8 @@ enum _TiledLayer {
   final String name;
 }
 
-class TrashyRoadWorld extends Component {
+class TrashyRoadWorld extends Component
+    with FlameBlocReader<GameBloc, GameState> {
   TrashyRoadWorld.create({required this.tiled}) {
     final trashGroup = tiled.tileMap.getLayer<ObjectGroup>(
       _TiledLayer.trashLayer.name,
@@ -87,8 +89,13 @@ class TrashyRoadWorld extends Component {
   late MapBounds bounds;
 
   @override
-  FutureOr<void> onLoad() async {
+  Future<void> onLoad() async {
     await super.onLoad();
     add(tiled);
+    bloc.add(
+      GameTrashAddedEvent(
+        amountOfTrash: tiled.children.whereType<Trash>().length,
+      ),
+    );
   }
 }

--- a/packages/trashy_road/lib/src/game/entities/player/behaviors/player_depositing_trash_behavior.dart
+++ b/packages/trashy_road/lib/src/game/entities/player/behaviors/player_depositing_trash_behavior.dart
@@ -1,7 +1,6 @@
 import 'package:flame/game.dart';
 import 'package:flame_behaviors/flame_behaviors.dart';
 import 'package:flame_bloc/flame_bloc.dart';
-import 'package:flutter/foundation.dart';
 import 'package:trashy_road/src/game/game.dart';
 
 /// Allows the [Player] to deposit [Trash] into a [TrashCan].
@@ -13,6 +12,6 @@ class PlayerDepositingTrashBehavior extends CollisionBehavior<TrashCan, Player>
   @override
   void onCollision(Set<Vector2> intersectionPoints, TrashCan other) {
     super.onCollision(intersectionPoints, other);
-    debugPrint('player hit the end game');
+    bloc.add(const GameDepositedTrashEvent());
   }
 }

--- a/packages/trashy_road/lib/src/game/view/game_page.dart
+++ b/packages/trashy_road/lib/src/game/view/game_page.dart
@@ -68,10 +68,12 @@ class _GameViewState extends State<_GameView> {
     return BlocBuilder<GameBloc, GameState>(
       buildWhen: (previous, current) {
         return previous.status == GameStatus.playing &&
-            current.status == GameStatus.resetting;
+            (current.status == GameStatus.resetting ||
+                current.status == GameStatus.completed);
       },
       builder: (context, state) {
-        if (state.status == GameStatus.resetting) {
+        if (state.status == GameStatus.resetting ||
+            state.status == GameStatus.completed) {
           _game = gameBuilder();
           gameBloc.add(const GameReadyEvent());
         }

--- a/packages/trashy_road/lib/src/game/widgets/inventory_hud.dart
+++ b/packages/trashy_road/lib/src/game/widgets/inventory_hud.dart
@@ -20,7 +20,7 @@ class InventoryHud extends StatelessWidget {
         padding: const EdgeInsets.all(8),
         child: BlocSelector<GameBloc, GameState, int>(
           selector: (state) {
-            return state.inventory.trash;
+            return state.trashRemaining;
           },
           builder: (context, trash) {
             return DefaultTextStyle(


### PR DESCRIPTION
#90 

Game will reset if the player collects all trash and deposits into trash can

Right now the interaction with the trash can is still through collision (temp)

and a visual representation is required to show that the user has trash in their inventory (holding trash over their back)