### PR TITLE
fix: make obstacles hitbox solid so less change to pass through

### DIFF
--- a/packages/trashy_road/lib/src/game/entities/obstacle/obstacle.dart
+++ b/packages/trashy_road/lib/src/game/entities/obstacle/obstacle.dart
@@ -17,6 +17,7 @@ class Obstacle extends PositionedEntity with Untraversable {
             ...?behaviors,
             PropagatingCollisionBehavior(
               RectangleHitbox(
+                isSolid: true,
                 anchor: Anchor.topCenter,
                 size: Vector2.all(0.8)..toGameSize(),
                 position:


### PR DESCRIPTION
On low fps, the player could get through the hitbox perimeter and be inside, which doesn't trigger the hitbox, whereas making the hitbox solid allows for more time for a collision to occur.

After this change I couldn't reproduce on andoird emulator in release mode, but is still easily possible in debug mode (~20 fps)