### PR TITLE
feat: show more horizontal tiles

### DIFF
--- a/packages/trashy_road/lib/src/game/debug_game.dart
+++ b/packages/trashy_road/lib/src/game/debug_game.dart
@@ -13,6 +13,7 @@ class DebugTrashyRoadGame extends TrashyRoadGame {
     required super.gameBloc,
     required super.effectPlayer,
     required super.random,
+    required super.resolution,
     super.images,
   }) {
     debugMode = true;

--- a/packages/trashy_road/lib/src/game/game.dart
+++ b/packages/trashy_road/lib/src/game/game.dart
@@ -31,12 +31,13 @@ class TrashyRoadGame extends FlameGame
     required GameBloc gameBloc,
     required this.effectPlayer,
     required this.random,
+    required Size resolution,
     Images? images,
   })  : _gameBloc = gameBloc,
         super(
           camera: CameraComponent.withFixedResolution(
-            width: 720,
-            height: 1280,
+            width: resolution.width,
+            height: resolution.height,
             viewfinder: Viewfinder()
               ..anchor = const Anchor(.5, .8)
               ..zoom = 1.2,

--- a/packages/trashy_road/lib/src/game/view/game_page.dart
+++ b/packages/trashy_road/lib/src/game/view/game_page.dart
@@ -79,7 +79,7 @@ class _GameView extends StatelessWidget {
       },
       child: Stack(
         children: [
-          const TrashyRoadGameWidget(),
+          const Align(child: TrashyRoadGameWidget()),
           const Align(
             alignment: Alignment.topCenter,
             child: Padding(

--- a/packages/trashy_road/lib/src/game/widgets/trashy_road_game_widget.dart
+++ b/packages/trashy_road/lib/src/game/widgets/trashy_road_game_widget.dart
@@ -4,6 +4,7 @@ import 'package:flame/game.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:trashy_road/game_settings.dart';
 import 'package:trashy_road/src/game/game.dart';
 import 'package:trashy_road/src/loading/loading.dart';
 
@@ -24,6 +25,10 @@ class _TrashyRoadGameWidgetState extends State<TrashyRoadGameWidget> {
     final gameBloc = context.read<GameBloc>();
     final audioBloc = context.read<AudioCubit>();
     final loadingBloc = context.read<PreloadCubit>();
+    final resolution = Size(
+      GameSettings.gridDimensions.x * 11,
+      (GameSettings.gridDimensions.x * 11) * (1280 / 720),
+    );
 
     TrashyRoadGame gameBuilder() {
       return kDebugMode
@@ -31,12 +36,14 @@ class _TrashyRoadGameWidgetState extends State<TrashyRoadGameWidget> {
               gameBloc: gameBloc,
               images: loadingBloc.images,
               effectPlayer: audioBloc.effectPlayer,
+              resolution: resolution,
               random: _random,
             )
           : TrashyRoadGame(
               gameBloc: gameBloc,
               images: loadingBloc.images,
               effectPlayer: audioBloc.effectPlayer,
+              resolution: resolution,
               random: _random,
             );
     }
@@ -52,7 +59,10 @@ class _TrashyRoadGameWidgetState extends State<TrashyRoadGameWidget> {
         setState(() => _game = gameBuilder());
         gameBloc.add(const GameReadyEvent());
       },
-      child: GameWidget(game: _game!),
+      child: SizedBox.fromSize(
+        size: resolution,
+        child: GameWidget(game: _game!),
+      ),
     );
   }
 }


### PR DESCRIPTION
Injects the resolution into the game. This is so we can leverage `MediaQuery.sizeOf(context)` when making the game layout responsive.

Related to #85 