### PR TITLE
fix: reduce CameraMan vertical displacement

### DIFF
--- a/packages/trashy_road/lib/src/game/game.dart
+++ b/packages/trashy_road/lib/src/game/game.dart
@@ -92,9 +92,7 @@ class TrashyRoadGame extends FlameGame
     unawaited(
       trashyRoadWorld.loaded.then((_) async {
         _player = trashyRoadWorld.children.whereType<Player>().first;
-        final cameraMan = _CameraMan(actor: _player!);
-        await world.add(cameraMan);
-        camera.follow(cameraMan);
+        camera.follow(_player!);
         _updateBounds();
       }),
     );
@@ -160,30 +158,5 @@ class TrashyRoadGame extends FlameGame
   void update(double dt) {
     super.update(dt);
     camera.update(dt);
-  }
-}
-
-class _CameraMan extends PositionComponent
-    with HasGameReference<TrashyRoadGame> {
-  _CameraMan({required this.actor});
-
-  final PositionComponent actor;
-
-  @override
-  FutureOr<void> onLoad() async {
-    await super.onLoad();
-    _updatePosition();
-  }
-
-  @override
-  void update(double dt) {
-    super.update(dt);
-    _updatePosition();
-  }
-
-  void _updatePosition() {
-    position
-      ..setFrom(actor.position)
-      ..y -= game.camera.viewport.size.y / 4.25;
   }
 }

--- a/packages/trashy_road/lib/src/game/game.dart
+++ b/packages/trashy_road/lib/src/game/game.dart
@@ -92,7 +92,9 @@ class TrashyRoadGame extends FlameGame
     unawaited(
       trashyRoadWorld.loaded.then((_) async {
         _player = trashyRoadWorld.children.whereType<Player>().first;
-        camera.follow(_player!);
+        final cameraMan = _CameraMan(actor: _player!);
+        await world.add(cameraMan);
+        camera.follow(cameraMan);
         _updateBounds();
       }),
     );
@@ -158,5 +160,30 @@ class TrashyRoadGame extends FlameGame
   void update(double dt) {
     super.update(dt);
     camera.update(dt);
+  }
+}
+
+class _CameraMan extends PositionComponent
+    with HasGameReference<TrashyRoadGame> {
+  _CameraMan({required this.actor});
+
+  final PositionComponent actor;
+
+  @override
+  FutureOr<void> onLoad() async {
+    await super.onLoad();
+    _updatePosition();
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _updatePosition();
+  }
+
+  void _updatePosition() {
+    position
+      ..setFrom(actor.position)
+      ..y -= game.camera.viewport.size.y / 8;
   }
 }


### PR DESCRIPTION
I think we should remove the `CameraMan` and bring the player back to the centre of the screen. So that the visibility when moving upwards or downwards is the same. Currently moving downwards has a significantly reduced visibility in comparison when moving downwards. 